### PR TITLE
更新SDK到1.9.2

### DIFF
--- a/src/ios/libs/README.txt
+++ b/src/ios/libs/README.txt
@@ -1,0 +1,135 @@
+重要!
+
+SDK1.9.2
+1. 新增发起企微客服会话能力
+
+SDK1.9.1
+1. 音乐视频分享类型增加运营H5字段
+
+SDK1.8.9
+1. 增加音乐视频分享类型
+
+SDK1.8.8
+1. 增加游戏直播消息类型
+
+SDK1.8.7.1
+1. 修复Xcode11以下编译不通过
+
+SDK1.8.7
+1. 修复iPadOS，未安装微信的情况下，因为UA问题无法授权登录
+2. 修复未安装微信的情况下, 适配了UIScene的App因为UIAlertView Crash
+3. 增加Universal Link检测函数
+
+SDK1.8.6.2
+1. 修改包含"UIWebView"字符的类名
+
+SDK1.8.6.1
+1.短信授权登录使用的UIWebview切换成WKWebview
+
+SDK1.8.6
+1. 支持Universal Link拉起微信以及返回App
+2. SDK移除MTA库
+
+SDK1.8.5
+1. 更换MTA库:取消对剪切板的访问, 防止和其他SDK竞争导致crash
+2. NSMutableArray的MTA分类方法改名，减少命名冲突
+3. 不含支付功能版本移除非税支付和医保支付接口
+4. 分享音乐支持填写歌词和高清封面图
+
+SDK1.8.4
+1. 调整分享图片大小限制
+2. 新增openBusinessView接口
+
+SDK1.8.3
+1. SDK增加调起微信刷卡支付接口
+2. SDK增加小程序订阅消息接口
+3. 修复小程序订阅消息接口没有resp的问题
+
+SDK1.8.2
+1. SDK增加开发票授权 WXInvoiceAuthInsert
+2. SDK增加非税接口   WXNontaxPay
+3. SDK增加医保接口   WXPayInsurance
+4. 更换MTA库
+
+SDK1.8.1
+1. SDK打开小程序支持指定版本（体验，开发，正式版）
+2. SDK分享小程序支持指定版本（体验，开发，正式版）
+3. SDK支持输出log日志
+
+SDK1.8.0
+1. SDK支持打开小程序
+2. SDK分享小程序支持shareTicket
+
+SDK1.7.9
+1. SDK订阅一次性消息
+
+SDK1.7.8
+1 SDK分享小程序支持大图
+
+SDK1.7.7
+1 增加SDK分享小程序
+2 增加选择发票接口
+
+SDK1.7.6
+1. 提高稳定性
+1 修复mta崩溃
+2  新增接口支持开发者关闭mta数据统计上报
+
+SDK1.7.5
+1. 提高稳定性
+2. 加快registerApp接口启动速度
+
+SDK1.7.4
+1. 更新支持iOS启用 ATS(App Transport Security)
+2. 需要在工程中链接CFNetwork.framework
+3. 在工程配置中的”Other Linker Flags”中加入”-Objc -all_load”
+
+SDK1.7.3
+1. 增强稳定性，适配iOS10
+2. 修复小于32K的jpg格式缩略图设置失败的问题
+
+SDK1.7.2
+1. 修复因CTTeleponyNetworkInfo引起的崩溃问题
+
+SDK1.7.1
+1. 支持兼容ipv6(提升稳定性)
+2. xCode Version 7.3.1 (7D1014) 编译
+
+SDK1.7
+1. 支持兼容ipv6
+2. 修复若干问题增强稳定性
+
+SDK1.6.3
+1. xCode7.2 构建的sdk包。
+2. 请使用xCode7.2进行编译。
+3. 需要在Build Phases中Link  Security.framework
+4. 修复若干小问题。
+
+SDK1.6.2
+1、xCode7.1 构建的sdk包
+2、请使用xCode7.1进行编译
+
+SDK1.6.1
+1、修复armv7s下,bitcode可能编译不过
+2、解决warning
+
+SDK1.6
+1、iOS 9系统策略更新，限制了http协议的访问，此外应用需要在“Info.plist”中将要使用的URL Schemes列为白名单，才可正常检查其他应用是否安装。
+受此影响，当你的应用在iOS 9中需要使用微信SDK的相关能力（分享、收藏、支付、登录等）时，需要在“Info.plist”里增加如下代码：
+<key>LSApplicationQueriesSchemes</key>
+<array>
+<string>weixin</string>
+</array>
+<key>NSAppTransportSecurity</key>
+<dict>
+<key>NSAllowsArbitraryLoads</key>
+<true/>
+</dict>
+2、开发者需要在工程中链接上 CoreTelephony.framework
+3、解决bitcode编译不过问题
+
+SDK1.5
+1、废弃safeSendReq:接口，使用sendReq:即可。
+2、新增+(BOOL) sendAuthReq:(SendAuthReq*) req viewController : (UIViewController*) viewController delegate:(id<WXApiDelegate>) delegate;
+支持未安装微信情况下Auth,具体见WXApi.h接口描述
+3、微信开放平台新增了微信模块用户统计功能，便于开发者统计微信功能模块的用户使用和活跃情况。开发者需要在工程中链接上:SystemConfiguration.framework,libz.dylib,libsqlite3.0.dylib。

--- a/src/ios/libs/WXApi.h
+++ b/src/ios/libs/WXApi.h
@@ -1,0 +1,205 @@
+//
+//  WXApi.h
+//  所有Api接口
+//
+//  Created by Wechat on 12-2-28.
+//  Copyright (c) 2012年 Tencent. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "WXApiObject.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - WXApiDelegate
+/*! @brief 接收并处理来自微信终端程序的事件消息
+ *
+ * 接收并处理来自微信终端程序的事件消息，期间微信界面会切换到第三方应用程序。
+ * WXApiDelegate 会在handleOpenURL:delegate:中使用并触发。
+ */
+@protocol WXApiDelegate <NSObject>
+@optional
+
+/*! @brief 收到一个来自微信的请求，第三方应用程序处理完后调用sendResp向微信发送结果
+ *
+ * 收到一个来自微信的请求，异步处理完成后必须调用sendResp发送处理结果给微信。
+ * 可能收到的请求有GetMessageFromWXReq、ShowMessageFromWXReq等。
+ * @param req 具体请求内容，是自动释放的
+ */
+- (void)onReq:(BaseReq*)req;
+
+
+
+/*! @brief 发送一个sendReq后，收到微信的回应
+ *
+ * 收到一个来自微信的处理结果。调用一次sendReq后会收到onResp。
+ * 可能收到的处理结果有SendMessageToWXResp、SendAuthResp等。
+ * @param resp具体的回应内容，是自动释放的
+ */
+- (void)onResp:(BaseResp*)resp;
+
+@end
+
+#pragma mark - WXApiLogDelegate
+
+@protocol WXApiLogDelegate <NSObject>
+
+- (void)onLog:(NSString*)log logLevel:(WXLogLevel)level;
+
+@end
+
+
+#pragma mark - WXApi
+
+/*! @brief 微信Api接口函数类
+ *
+ * 该类封装了微信终端SDK的所有接口
+ */
+@interface WXApi : NSObject
+
+/*! @brief WXApi的成员函数，向微信终端程序注册第三方应用。
+ *
+ * 需要在每次启动第三方应用程序时调用。
+ * @attention 请保证在主线程中调用此函数
+ * @param appid 微信开发者ID
+ * @param universalLink 微信开发者Universal Link
+ * @return 成功返回YES，失败返回NO。
+ */
++ (BOOL)registerApp:(NSString *)appid universalLink:(NSString *)universalLink;
+
+
+/*! @brief 处理旧版微信通过URL启动App时传递的数据
+ *
+ * 需要在 application:openURL:sourceApplication:annotation:或者application:handleOpenURL中调用。
+ * @param url 微信启动第三方应用时传递过来的URL
+ * @param delegate  WXApiDelegate对象，用来接收微信触发的消息。
+ * @return 成功返回YES，失败返回NO。
+ */
++ (BOOL)handleOpenURL:(NSURL *)url delegate:(nullable id<WXApiDelegate>)delegate;
+
+
+/*! @brief 处理微信通过Universal Link启动App时传递的数据
+ *
+ * 需要在 application:continueUserActivity:restorationHandler:中调用。
+ * @param userActivity 微信启动第三方应用时系统API传递过来的userActivity
+ * @param delegate  WXApiDelegate对象，用来接收微信触发的消息。
+ * @return 成功返回YES，失败返回NO。
+ */
++ (BOOL)handleOpenUniversalLink:(NSUserActivity *)userActivity delegate:(nullable id<WXApiDelegate>)delegate;
+
+
+/*! @brief 检查微信是否已被用户安装
+ *
+ * @return 微信已安装返回YES，未安装返回NO。
+ */
++ (BOOL)isWXAppInstalled;
+
+
+
+/*! @brief 判断当前微信的版本是否支持OpenApi
+ *
+ * @return 支持返回YES，不支持返回NO。
+ */
++ (BOOL)isWXAppSupportApi;
+
+
+/*! @brief 判断当前微信的版本是否支持分享微信状态功能
+ *
+ * @attention 需在工程LSApplicationQueriesSchemes配置中添加weixinStateAPI
+ * @return 支持返回YES，不支持返回NO。
+ */
++ (BOOL)isWXAppSupportStateAPI;
+
+
+/*! @brief 获取微信的itunes安装地址
+ *
+ * @return 微信的安装地址字符串。
+ */
++ (NSString *)getWXAppInstallUrl;
+
+
+
+/*! @brief 获取当前微信SDK的版本号
+ *
+ * @return 返回当前微信SDK的版本号
+ */
++ (NSString *)getApiVersion;
+
+
+
+/*! @brief 打开微信
+ *
+ * @return 成功返回YES，失败返回NO。
+ */
++ (BOOL)openWXApp;
+
+
+
+/*! @brief 发送请求到微信，等待微信返回onResp
+ *
+ * 函数调用后，会切换到微信的界面。第三方应用程序等待微信返回onResp。微信在异步处理完成后一定会调用onResp。支持以下类型
+ * SendAuthReq、SendMessageToWXReq、PayReq等。
+ * @param req 具体的发送请求。
+ * @param completion 调用结果回调block
+ */
++ (void)sendReq:(BaseReq *)req completion:(void (^ __nullable)(BOOL success))completion;
+
+/*! @brief 收到微信onReq的请求，发送对应的应答给微信，并切换到微信界面
+ *
+ * 函数调用后，会切换到微信的界面。第三方应用程序收到微信onReq的请求，异步处理该请求，完成后必须调用该函数。可能发送的相应有
+ * GetMessageFromWXResp、ShowMessageFromWXResp等。
+ * @param resp 具体的应答内容
+ * @param completion 调用结果回调block
+ */
++ (void)sendResp:(BaseResp*)resp completion:(void (^ __nullable)(BOOL success))completion;
+
+
+/*! @brief 发送Auth请求到微信，支持用户没安装微信，等待微信返回onResp
+ *
+ * 函数调用后，会切换到微信的界面。第三方应用程序等待微信返回onResp。微信在异步处理完成后一定会调用onResp。支持SendAuthReq类型。
+ * @param req 具体的发送请求。
+ * @param viewController 当前界面对象。
+ * @param delegate  WXApiDelegate对象，用来接收微信触发的消息。
+ * @param completion 调用结果回调block
+ */
++ (void)sendAuthReq:(SendAuthReq *)req viewController:(UIViewController*)viewController delegate:(nullable id<WXApiDelegate>)delegate completion:(void (^ __nullable)(BOOL success))completion;
+
+
+/*! @brief 测试函数，用于排查当前App通过Universal Link方式分享到微信的流程
+    注意1:  调用自检函数之前必须要先调用registerApp:universalLink接口, 并确认调用成功
+    注意2:  自检过程中会有Log产生，可以先调用startLogByLevel函数，根据Log排查问题
+    注意3:  会多次回调block
+    注意4:  仅用于新接入SDK时调试使用，请勿在正式环境的调用
+ *
+ *  当completion回调的step为WXULCheckStepFinal时，表示检测通过，Universal Link接入成功
+ *  @param completion 回调Block
+ */
++ (void)checkUniversalLinkReady:(nonnull WXCheckULCompletion)completion;
+
+
+/*! @brief WXApi的成员函数，接受微信的log信息。byBlock
+    注意1:SDK会强引用这个block,注意不要导致内存泄漏,注意不要导致内存泄漏
+    注意2:调用过一次startLog by block之后，如果再调用一次任意方式的startLoad,会释放上一次logBlock，不再回调上一个logBlock
+ *
+ *  @param level 打印log的级别
+ *  @param logBlock 打印log的回调block
+ */
+
++ (void)startLogByLevel:(WXLogLevel)level logBlock:(WXLogBolock)logBlock;
+
+/*! @brief WXApi的成员函数，接受微信的log信息。byDelegate 
+    注意1:sdk会弱引用这个delegate，这里可加任意对象为代理，不需要与WXApiDelegate同一个对象
+    注意2:调用过一次startLog by delegate之后，再调用一次任意方式的startLoad,不会再回调上一个logDelegate对象
+ *  @param level 打印log的级别
+ *  @param logDelegate 打印log的回调代理，
+ */
++ (void)startLogByLevel:(WXLogLevel)level logDelegate:(id<WXApiLogDelegate>)logDelegate;
+
+/*! @brief 停止打印log，会清理block或者delegate为空，释放block
+ *  @param 
+ */
++ (void)stopLog;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/libs/WXApiObject.h
+++ b/src/ios/libs/WXApiObject.h
@@ -1,0 +1,1247 @@
+//
+//  MMApiObject.h
+//  Api对象，包含所有接口和对象数据定义
+//
+//  Created by Wechat on 12-2-28.
+//  Copyright (c) 2012年 Tencent. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! @brief 错误码
+ *
+ */
+enum  WXErrCode {
+    WXSuccess           = 0,    /**< 成功    */
+    WXErrCodeCommon     = -1,   /**< 普通错误类型    */
+    WXErrCodeUserCancel = -2,   /**< 用户点击取消并返回    */
+    WXErrCodeSentFail   = -3,   /**< 发送失败    */
+    WXErrCodeAuthDeny   = -4,   /**< 授权失败    */
+    WXErrCodeUnsupport  = -5,   /**< 微信不支持    */
+};
+
+
+
+/*! @brief 请求发送场景
+ *
+ */
+enum WXScene {
+    WXSceneSession          = 0,   /**< 聊天界面    */
+    WXSceneTimeline         = 1,   /**< 朋友圈     */
+    WXSceneFavorite         = 2,   /**< 收藏       */
+    WXSceneSpecifiedSession = 3,   /**< 指定联系人  */
+    WXSceneState            = 4,   /**< 状态  */
+};
+
+
+enum WXAPISupport {
+    WXAPISupportSession = 0,
+};
+
+
+
+/*! @brief 跳转profile类型
+ *
+ */
+enum WXBizProfileType {
+    WXBizProfileType_Normal = 0,    //**< 普通公众号  */
+    WXBizProfileType_Device = 1,    //**< 硬件公众号  */
+};
+
+/*! @brief 分享小程序类型
+ *
+ */
+typedef NS_ENUM(NSUInteger, WXMiniProgramType) {
+    WXMiniProgramTypeRelease = 0,       //**< 正式版  */
+    WXMiniProgramTypeTest = 1,        //**< 开发版  */
+    WXMiniProgramTypePreview = 2,         //**< 体验版  */
+};
+
+/*! @brief 跳转mp网页类型
+ *
+ */
+enum WXMPWebviewType {
+    WXMPWebviewType_Ad = 0,        /**< 广告网页 **/
+};
+
+/*! @brief log的级别
+ *
+ */
+typedef NS_ENUM(NSInteger,WXLogLevel) {
+    WXLogLevelNormal = 0,      // 打印日常的日志
+    WXLogLevelDetail = 1,      // 打印详细的日志
+};
+
+
+/*! @brief 打印回调的block
+ *
+ */
+typedef void(^WXLogBolock)(NSString *log);
+
+/*! @brief 微信Universal Link检查函数 (WXApi#checkUniversalLinkReady:)，检查步骤枚举值
+ *
+ * WXULCheckStepParams 参数检测
+ * WXULCheckStepSystemVersion 当前系统版本检测
+ * WXULCheckStepWechatVersion 微信客户端版本检测
+ * WXULCheckStepSDKInnerOperation 微信SDK内部操作检测
+ * WXULCheckStepLaunchWechat  App拉起微信检测
+ * WXULCheckStepBackToCurrentApp 由微信返回当前App检测
+ * WXULCheckStepFinal 最终结果
+ */
+typedef NS_ENUM(NSInteger, WXULCheckStep)
+{
+    WXULCheckStepParams,
+    WXULCheckStepSystemVersion,
+    WXULCheckStepWechatVersion,
+    WXULCheckStepSDKInnerOperation,
+    WXULCheckStepLaunchWechat,
+    WXULCheckStepBackToCurrentApp,
+    WXULCheckStepFinal,
+};
+
+
+#pragma mark - WXCheckULStepResult
+
+/*! @brief 该类为微信Universal Link检测函数结果类
+*
+*/
+@interface WXCheckULStepResult : NSObject
+
+/** 是否成功 */
+@property(nonatomic, assign) BOOL success;
+/** 当前错误信息 */
+@property(nonatomic, strong) NSString* errorInfo;
+/** 修正建议 */
+@property(nonatomic, strong) NSString* suggestion;
+
+- (instancetype)initWithCheckResult:(BOOL)success errorInfo:(nullable NSString*)errorInfo suggestion:(nullable NSString*)suggestion;
+
+@end
+
+
+/*! @brief 微信Universal Link检查函数 (WXApi#checkUniversalLinkReady:)，回调Block
+ *
+ * @param step 当前检测步骤
+ * @param result 检测结果
+ */
+typedef void(^WXCheckULCompletion)(WXULCheckStep step, WXCheckULStepResult* result);
+
+
+#pragma mark - BaseReq
+/*! @brief 该类为微信终端SDK所有请求类的基类
+ *
+ */
+@interface BaseReq : NSObject
+
+/** 请求类型 */
+@property (nonatomic, assign) int type;
+/** 由用户微信号和AppID组成的唯一标识，需要校验微信用户是否换号登录时填写*/
+@property (nonatomic, copy) NSString *openID;
+
+@end
+
+
+
+#pragma mark - BaseResp
+/*! @brief 该类为微信终端SDK所有响应类的基类
+ *
+ */
+@interface BaseResp : NSObject
+/** 错误码 */
+@property (nonatomic, assign) int errCode;
+/** 错误提示字符串 */
+@property (nonatomic, copy) NSString *errStr;
+/** 响应类型 */
+@property (nonatomic, assign) int type;
+
+@end
+
+
+
+#pragma mark - WXMediaMessage
+@class WXMediaMessage;
+
+#ifndef BUILD_WITHOUT_PAY
+
+#pragma mark - PayReq
+/*! @brief 第三方向微信终端发起支付的消息结构体
+ *
+ *  第三方向微信终端发起支付的消息结构体，微信终端处理后会向第三方返回处理结果
+ * @see PayResp
+ */
+@interface PayReq : BaseReq
+
+/** 商家向财付通申请的商家id */
+@property (nonatomic, copy) NSString *partnerId;
+/** 预支付订单 */
+@property (nonatomic, copy) NSString *prepayId;
+/** 随机串，防重发 */
+@property (nonatomic, copy) NSString *nonceStr;
+/** 时间戳，防重发 */
+@property (nonatomic, assign) UInt32 timeStamp;
+/** 商家根据财付通文档填写的数据和签名 */
+@property (nonatomic, copy) NSString *package;
+/** 商家根据微信开放平台文档对数据做的签名 */
+@property (nonatomic, copy) NSString *sign;
+
+@end
+
+
+#pragma mark - PayResp
+/*! @brief 微信终端返回给第三方的关于支付结果的结构体
+ *
+ *  微信终端返回给第三方的关于支付结果的结构体
+ */
+@interface PayResp : BaseResp
+
+/** 财付通返回给商家的信息 */
+@property (nonatomic, copy) NSString *returnKey;
+
+@end
+
+#pragma mark - WXOfflinePay
+/*! @brief 第三方向微信终端发起离线支付
+ *
+ *  第三方向微信终端发起离线支付的消息结构体
+ */
+@interface WXOfflinePayReq : BaseReq
+
+@end
+
+/*! @brief 第三方向微信终端发起离线支付返回
+ *
+ *  第三方向微信终端发起离线支付返回的消息结构体
+ */
+@interface WXOfflinePayResp : BaseResp
+
+@end
+
+
+#pragma mark - WXNontaxPayReq
+@interface WXNontaxPayReq:BaseReq
+
+@property (nonatomic, copy) NSString *urlString;
+
+@end
+
+#pragma mark - WXNontaxPayResp
+@interface WXNontaxPayResp : BaseResp
+
+@property (nonatomic, copy) NSString *wxOrderId;
+
+@end
+
+#pragma mark - WXPayInsuranceReq
+@interface WXPayInsuranceReq : BaseReq
+
+@property (nonatomic, copy) NSString *urlString;
+
+@end
+
+#pragma mark - WXPayInsuranceResp
+@interface WXPayInsuranceResp : BaseResp
+
+@property (nonatomic, copy) NSString *wxOrderId;
+
+@end
+
+#endif
+
+
+#pragma mark - SendAuthReq
+/*! @brief 第三方程序向微信终端请求认证的消息结构
+ *
+ * 第三方程序要向微信申请认证，并请求某些权限，需要调用WXApi的sendReq成员函数，
+ * 向微信终端发送一个SendAuthReq消息结构。微信终端处理完后会向第三方程序发送一个处理结果。
+ * @see SendAuthResp
+ */
+@interface SendAuthReq : BaseReq
+/** 第三方程序要向微信申请认证，并请求某些权限，需要调用WXApi的sendReq成员函数，向微信终端发送一个SendAuthReq消息结构。微信终端处理完后会向第三方程序发送一个处理结果。
+ * @see SendAuthResp
+ * @note scope字符串长度不能超过1K
+ */
+@property (nonatomic, copy) NSString *scope;
+/** 第三方程序本身用来标识其请求的唯一性，最后跳转回第三方程序时，由微信终端回传。
+ * @note state字符串长度不能超过1K
+ */
+@property (nonatomic, copy) NSString *state;
+
+@end
+
+#pragma mark - SendAuthResp
+/*! @brief 微信处理完第三方程序的认证和权限申请后向第三方程序回送的处理结果。
+ *
+ * 第三方程序要向微信申请认证，并请求某些权限，需要调用WXApi的sendReq成员函数，向微信终端发送一个SendAuthReq消息结构。
+ * 微信终端处理完后会向第三方程序发送一个SendAuthResp。
+ * @see onResp
+ */
+@interface SendAuthResp : BaseResp
+@property (nonatomic, copy, nullable) NSString *code;
+/** 第三方程序发送时用来标识其请求的唯一性的标志，由第三方程序调用sendReq时传入，由微信终端回传
+ * @note state字符串长度不能超过1K
+ */
+@property (nonatomic, copy, nullable) NSString *state;
+@property (nonatomic, copy, nullable) NSString *lang;
+@property (nonatomic, copy, nullable) NSString *country;
+@end
+
+#pragma mark - WXStateJumpInfo
+/*! @brief 状态发表时的小尾巴跳转信息
+ */
+@interface WXStateJumpInfo : NSObject
+
+@end
+
+#pragma mark - WXStateJumpUrlInfo
+/*! @brief 状态小尾巴跳转指定url的信息
+ */
+@interface WXStateJumpUrlInfo : WXStateJumpInfo
+/** 跳转到指定的url
+ * @note 必填，url长度必须大于0且小于10K
+ */
+@property (nonatomic, copy) NSString *url;
+
+@end
+
+#pragma mark - WXStateSceneDataObject
+/*! @brief 场景类型额外参数基类
+ */
+@interface WXSceneDataObject : NSObject
+
+@end
+
+#pragma mark - WXStateSceneDataObject
+/*! @brief 状态场景类型
+ * 用户填写WXStateSceneDataObject参数后，可以跳转到微信状态发表页
+ */
+@interface WXStateSceneDataObject : WXSceneDataObject
+
+/** 状态标志的ID
+ * @note 选填，文本长度必须小于10K
+ */
+@property (nonatomic, copy) NSString *stateId;
+/** 状态发表时附带的文本描述
+ * @note 选填，文本长度必须小于10K
+ */
+@property (nonatomic, copy) NSString *stateTitle;
+/** 后台校验token
+ * @note 选填，文本长度必须小于10K
+ */
+@property (nonatomic, copy) NSString *token;
+/** 小尾巴跳转所需的信息
+ * @note 必填，目前仅支持url跳转
+ */
+@property (nonatomic, strong) WXStateJumpInfo *stateJumpDataInfo;
+
+@end
+
+#pragma mark - SendMessageToWXReq
+/*! @brief 第三方程序发送消息至微信终端程序的消息结构体
+ *
+ * 第三方程序向微信发送信息需要传入SendMessageToWXReq结构体，信息类型包括文本消息和多媒体消息，
+ * 分别对应于text和message成员。调用该方法后，微信处理完信息会向第三方程序发送一个处理结果。
+ * @see SendMessageToWXResp
+ */
+@interface SendMessageToWXReq : BaseReq
+/** 发送消息的文本内容
+ * @note 文本长度必须大于0且小于10K
+ */
+@property (nonatomic, copy) NSString *text;
+/** 发送消息的多媒体内容
+ * @see WXMediaMessage
+ */
+@property (nonatomic, strong) WXMediaMessage *message;
+/** 发送消息的类型，包括文本消息和多媒体消息两种，两者只能选择其一，不能同时发送文本和多媒体消息 */
+@property (nonatomic, assign) BOOL bText;
+/** 发送的目标场景，可以选择发送到会话(WXSceneSession)或者朋友圈(WXSceneTimeline)。 默认发送到会话。
+ * @see WXScene
+ */
+@property (nonatomic, assign) int scene;
+/** 指定发送消息的人
+ * @note WXSceneSpecifiedSession时有效
+ */
+@property (nonatomic, copy, nullable) NSString *toUserOpenId;
+/** 目标场景附带信息
+ * @note 目前只针对状态场景
+ */
+@property (nonatomic, strong) WXSceneDataObject *sceneDataObject;
+
+@end
+
+#pragma mark - SendMessageToWXResp
+/*! @brief 微信终端向第三方程序返回的SendMessageToWXReq处理结果。
+ *
+ * 第三方程序向微信终端发送SendMessageToWXReq后，微信发送回来的处理结果，该结果用SendMessageToWXResp表示。
+ */
+@interface SendMessageToWXResp : BaseResp
+@property(nonatomic, copy) NSString *lang;
+@property(nonatomic, copy) NSString *country;
+@end
+
+#pragma mark - GetMessageFromWXReq
+/*! @brief 微信终端向第三方程序请求提供内容的消息结构体。
+ *
+ * 微信终端向第三方程序请求提供内容，微信终端会向第三方程序发送GetMessageFromWXReq消息结构体，
+ * 需要第三方程序调用sendResp返回一个GetMessageFromWXResp消息结构体。
+ */
+@interface GetMessageFromWXReq : BaseReq
+@property (nonatomic, strong) NSString *lang;
+@property (nonatomic, strong) NSString *country;
+@end
+
+
+
+#pragma mark - GetMessageFromWXResp
+/*! @brief 微信终端向第三方程序请求提供内容，第三方程序向微信终端返回的消息结构体。
+ *
+ * 微信终端向第三方程序请求提供内容，第三方程序调用sendResp向微信终端返回一个GetMessageFromWXResp消息结构体。
+ */
+@interface GetMessageFromWXResp : BaseResp
+/** 向微信终端提供的文本内容
+ @note 文本长度必须大于0且小于10K
+ */
+@property (nonatomic, strong) NSString *text;
+/** 向微信终端提供的多媒体内容。
+ * @see WXMediaMessage
+ */
+@property (nonatomic, strong) WXMediaMessage *message;
+/** 向微信终端提供内容的消息类型，包括文本消息和多媒体消息两种，两者只能选择其一，不能同时发送文本和多媒体消息 */
+@property (nonatomic, assign) BOOL bText;
+@end
+
+
+
+#pragma mark - ShowMessageFromWXReq
+/*! @brief 微信通知第三方程序，要求第三方程序显示的消息结构体。
+ *
+ * 微信需要通知第三方程序显示或处理某些内容时，会向第三方程序发送ShowMessageFromWXReq消息结构体。
+ * 第三方程序处理完内容后调用sendResp向微信终端发送ShowMessageFromWXResp。
+ */
+@interface ShowMessageFromWXReq : BaseReq
+/** 微信终端向第三方程序发送的要求第三方程序处理的多媒体内容
+ * @see WXMediaMessage
+ */
+@property (nonatomic, strong) WXMediaMessage *message;
+@property (nonatomic, copy) NSString *lang;
+@property (nonatomic, copy) NSString *country;
+@end
+
+
+
+#pragma mark - ShowMessageFromWXResp
+/*! @brief 微信通知第三方程序，要求第三方程序显示或处理某些消息，第三方程序处理完后向微信终端发送的处理结果。
+ *
+ * 微信需要通知第三方程序显示或处理某些内容时，会向第三方程序发送ShowMessageFromWXReq消息结构体。
+ * 第三方程序处理完内容后调用sendResp向微信终端发送ShowMessageFromWXResp。
+ */
+@interface ShowMessageFromWXResp : BaseResp
+@end
+
+
+#pragma mark - LaunchFromWXReq
+/*! @brief 微信终端打开第三方程序携带的消息结构体
+ *
+ *  微信向第三方发送的结构体，第三方不需要返回
+ */
+@interface LaunchFromWXReq : BaseReq
+@property (nonatomic, strong) WXMediaMessage *message;
+@property (nonatomic, copy) NSString *lang;
+@property (nonatomic, copy) NSString *country;
+@end
+
+
+#pragma mark - OpenWebviewReq
+/* ! @brief 第三方通知微信启动内部浏览器，打开指定网页
+ *
+ *  第三方通知微信启动内部浏览器，打开指定Url对应的网页
+ */
+@interface OpenWebviewReq : BaseReq
+/** 需要打开的网页对应的Url
+ * @attention 长度不能超过1024
+ */
+@property(nonatomic, copy) NSString *url;
+
+@end
+
+#pragma mark - OpenWebviewResp
+/*! @brief 微信终端向第三方程序返回的OpenWebviewReq处理结果
+ *
+ * 第三方程序向微信终端发送OpenWebviewReq后，微信发送回来的处理结果，该结果用OpenWebviewResp表示
+ */
+@interface OpenWebviewResp : BaseResp
+
+@end
+
+
+
+#pragma mark - WXOpenBusinessWebViewReq
+/*! @brief 第三方通知微信启动内部浏览器，打开指定业务的网页
+ *
+ *
+ */
+@interface WXOpenBusinessWebViewReq : BaseReq
+
+/** 网页业务类型
+ * @attention
+ */
+@property (nonatomic, assign) UInt32 businessType;
+
+/** 网页业务参数
+ * @attention
+ */
+@property (nonatomic, strong, nullable) NSDictionary *queryInfoDic;
+
+@end
+
+#pragma mark - WXOpenBusinessWebViewResp
+/*! @brief 微信终端向第三方程序返回的WXOpenBusinessWebViewResp处理结果。
+ *
+ * 第三方程序向微信终端发送WXOpenBusinessWebViewReq后，微信发送回来的处理结果，该结果用WXOpenBusinessWebViewResp表示。
+ */
+@interface WXOpenBusinessWebViewResp : BaseResp
+/** 第三方程序自定义简单数据，微信终端会回传给第三方程序处理
+ * @attention 长度不能超过2k
+ */
+@property (nonatomic, copy) NSString *result;
+
+/** 网页业务类型
+ * @attention
+ */
+@property (nonatomic, assign) UInt32 businessType;
+
+@end
+
+
+#pragma mark - OpenRankListReq
+/* ! @brief 第三方通知微信，打开硬件排行榜
+ *
+ * 第三方通知微信，打开硬件排行榜
+ */
+@interface OpenRankListReq : BaseReq
+
+@end
+
+#pragma mark - OpenRanklistResp
+/*! @brief 微信终端向第三方程序返回的OpenRankListReq处理结果。
+ *
+ * 第三方程序向微信终端发送OpenRankListReq后，微信发送回来的处理结果，该结果用OpenRankListResp表示。
+ */
+@interface OpenRankListResp : BaseResp
+
+@end
+
+
+#pragma mark - WXCardItem
+
+@interface WXCardItem : NSObject
+/** 卡id
+ * @attention 长度不能超过1024字节
+ */
+@property (nonatomic, copy) NSString *cardId;
+/** ext信息
+ * @attention 长度不能超过2024字节
+ */
+@property (nonatomic, copy, nullable) NSString *extMsg;
+/**
+ * @attention 卡的状态,req不需要填。resp:0为未添加，1为已添加。
+ */
+@property (nonatomic, assign) UInt32 cardState;
+/**
+ * @attention req不需要填，chooseCard返回的。
+ */
+@property (nonatomic, copy) NSString *encryptCode;
+/**
+ * @attention req不需要填，chooseCard返回的。
+ */
+@property (nonatomic, copy) NSString *appID;
+@end;
+
+#pragma mark - WXInvoiceItem
+
+@interface WXInvoiceItem : NSObject
+/** 卡id
+ * @attention 长度不能超过1024字节
+ */
+@property (nonatomic, copy) NSString *cardId;
+/** ext信息
+ * @attention 长度不能超过2024字节
+ */
+@property (nonatomic, copy, nullable) NSString *extMsg;
+/**
+ * @attention 卡的状态,req不需要填。resp:0为未添加，1为已添加。
+ */
+@property (nonatomic, assign) UInt32 cardState;
+/**
+ * @attention req不需要填，chooseCard返回的。
+ */
+@property (nonatomic, copy) NSString *encryptCode;
+/**
+ * @attention req不需要填，chooseCard返回的。
+ */
+@property (nonatomic, copy) NSString *appID;
+
+@end
+
+#pragma mark - AddCardToWXCardPackageReq
+/* ! @brief 请求添加卡券至微信卡包
+ *
+ */
+
+@interface AddCardToWXCardPackageReq : BaseReq
+/** 卡列表
+ * @attention 个数不能超过40个 类型WXCardItem
+ */
+@property (nonatomic, strong) NSArray *cardAry;
+
+@end
+
+
+#pragma mark - AddCardToWXCardPackageResp
+/** ! @brief 微信返回第三方添加卡券结果
+ *
+ */
+
+@interface AddCardToWXCardPackageResp : BaseResp
+/** 卡列表
+ * @attention 个数不能超过40个 类型WXCardItem
+ */
+@property (nonatomic, strong) NSArray *cardAry;
+@end
+
+#pragma mark - WXChooseCardReq
+/* ! @brief 请求从微信选取卡券
+ *
+ */
+
+@interface WXChooseCardReq : BaseReq
+@property (nonatomic, copy) NSString *appID;
+@property (nonatomic, assign) UInt32 shopID;
+@property (nonatomic, assign) UInt32 canMultiSelect;
+@property (nonatomic, copy) NSString *cardType;
+@property (nonatomic, copy) NSString *cardTpID;
+@property (nonatomic, copy) NSString *signType;
+@property (nonatomic, copy) NSString *cardSign;
+@property (nonatomic, assign) UInt32 timeStamp;
+@property (nonatomic, copy) NSString *nonceStr;
+@end
+
+
+#pragma mark - WXChooseCardResp
+/** ! @brief 微信返回第三方请求选择卡券结果
+ *
+ */
+
+@interface WXChooseCardResp : BaseResp
+@property (nonatomic, strong ) NSArray* cardAry;
+@end
+
+
+#pragma mark - WXChooseInvoiceReq
+/* ! @brief 请求从微信选取发票
+ *
+ */
+@interface WXChooseInvoiceReq : BaseReq
+@property (nonatomic, copy) NSString *appID;
+@property (nonatomic, assign) UInt32 shopID;
+@property (nonatomic, copy) NSString *signType;
+@property (nonatomic, copy) NSString *cardSign;
+@property (nonatomic, assign) UInt32 timeStamp;
+@property (nonatomic, copy) NSString *nonceStr;
+@end
+
+#pragma mark - WXChooseInvoiceResp
+/** ! @brief 微信返回第三方请求选择发票结果
+ *
+ */
+@interface WXChooseInvoiceResp : BaseResp
+@property (nonatomic, strong) NSArray* cardAry;
+@end
+
+#pragma mark - WXSubscriptionReq
+@interface WXSubscribeMsgReq : BaseReq
+@property (nonatomic, assign) UInt32 scene;
+@property (nonatomic, copy) NSString *templateId;
+@property (nonatomic, copy, nullable) NSString *reserved;
+@end
+
+#pragma mark - WXSubscriptionReq
+@interface WXSubscribeMsgResp : BaseResp
+
+@property (nonatomic, copy) NSString *templateId;
+@property (nonatomic, assign) UInt32 scene;
+@property (nonatomic, copy) NSString *action;
+@property (nonatomic, copy) NSString *reserved;
+@property (nonatomic, copy, nullable) NSString *openId;
+
+@end
+
+#pragma mark - WXSubscribeMiniProgramMsg
+/** ! @brief 第三方请求订阅小程序消息
+ *
+ */
+@interface WXSubscribeMiniProgramMsgReq : BaseReq
+@property (nonatomic, copy) NSString *miniProgramAppid;
+@end
+
+#pragma mark - WXSubscriptionReq
+@interface WXSubscribeMiniProgramMsgResp : BaseResp
+
+@property(nonatomic, copy) NSString *openId;   // 小程序openid
+@property(nonatomic, copy) NSString *unionId;  // unionId
+@property(nonatomic, copy) NSString *nickName; // 用户昵称
+
+@end
+
+#pragma mark - WXinvoiceAuthInsertReq
+@interface WXInvoiceAuthInsertReq : BaseReq
+
+@property (nonatomic, copy) NSString *urlString;
+
+@end
+
+#pragma mark - WXinvoiceAuthInsertResp
+
+@interface WXInvoiceAuthInsertResp : BaseResp
+
+@property (nonatomic, copy) NSString *wxOrderId;
+
+@end
+
+#pragma mark - WXMediaMessage
+
+/*! @brief 多媒体消息结构体
+ *
+ * 用于微信终端和第三方程序之间传递消息的多媒体消息内容
+ */
+@interface WXMediaMessage : NSObject
+
++ (WXMediaMessage *)message;
+
+/** 标题
+ * @note 长度不能超过512字节
+ */
+@property (nonatomic, copy) NSString *title;
+/** 描述内容
+ * @note 长度不能超过1K
+ */
+@property (nonatomic, copy) NSString *description;
+/** 缩略图数据
+ * @note 大小不能超过64K
+ */
+@property (nonatomic, strong, nullable) NSData *thumbData;
+/**
+ * @note 长度不能超过64字节
+ */
+@property (nonatomic, copy, nullable) NSString *mediaTagName;
+/**
+ *
+ */
+@property (nonatomic, copy, nullable) NSString *messageExt;
+@property (nonatomic, copy, nullable) NSString *messageAction;
+/**
+ * 多媒体数据对象，可以为WXImageObject，WXMusicObject，WXVideoObject，WXWebpageObject等。
+ */
+@property (nonatomic, strong) id mediaObject;
+
+/*! @brief 设置消息缩略图的方法
+ *
+ * @param image 缩略图
+ * @note 大小不能超过64K
+ */
+- (void)setThumbImage:(UIImage *)image;
+
+@end
+
+
+
+#pragma mark - WXImageObject
+/*! @brief 多媒体消息中包含的图片数据对象
+ *
+ * 微信终端和第三方程序之间传递消息中包含的图片数据对象。
+ * @note imageData成员不能为空
+ * @see WXMediaMessage
+ */
+@interface WXImageObject : NSObject
+/*! @brief 返回一个WXImageObject对象
+ *
+ * @note 返回的WXImageObject对象是自动释放的
+ */
++ (WXImageObject *)object;
+
+/** 图片真实数据内容
+ * @note 大小不能超过25M
+ */
+@property (nonatomic, strong) NSData *imageData;
+
+@end
+
+
+#pragma mark - WXMusicObject
+/*! @brief 多媒体消息中包含的音乐数据对象
+ *
+ * 微信终端和第三方程序之间传递消息中包含的音乐数据对象。
+ * @note musicUrl和musicLowBandUrl成员不能同时为空。
+ * @see WXMediaMessage
+ */
+@interface WXMusicObject : NSObject
+/*! @brief 返回一个WXMusicObject对象
+ *
+ * @note 返回的WXMusicObject对象是自动释放的
+ */
++ (WXMusicObject *)object;
+
+/** 音乐网页的url地址
+ * @note 长度不能超过10K
+ */
+@property (nonatomic, copy) NSString *musicUrl;
+/** 音乐lowband网页的url地址
+ * @note 长度不能超过10K
+ */
+@property (nonatomic, copy) NSString *musicLowBandUrl;
+/** 音乐数据url地址
+ * @note 长度不能超过10K
+ */
+@property (nonatomic, copy) NSString *musicDataUrl;
+
+/**音乐lowband数据url地址
+ * @note 长度不能超过10K
+ */
+@property (nonatomic, copy) NSString *musicLowBandDataUrl;
+
+/**音乐封面图Url
+ * @note 长度不能超过10K
+ */
+@property (nonatomic, copy) NSString *songAlbumUrl;
+
+/**歌词信息 LRC格式
+ * @note 长度不能超过32K
+ */
+@property (nonatomic, copy, nullable) NSString *songLyric;
+@end
+
+
+
+#pragma mark - WXMusicVideoObject
+
+
+@interface WXMusicVideoObject : NSObject
+
+/*! @brief 返回一个WXMusicVideoObject对象
+ *
+ * @note 返回的WXMusicVideoObject对象是自动释放的
+ */
++ (WXMusicVideoObject *)object;
+
+/** 音乐网页的url地址
+ * @note 长度不能超过10K，不能为空
+ */
+@property (nonatomic, copy) NSString *musicUrl;
+
+/** 音乐数据url地址
+ * @note 长度不能超过10K，不能为空
+ */
+@property (nonatomic, copy) NSString *musicDataUrl;
+
+/**歌手名
+ * @note 长度不能超过1k，不能为空
+ */
+@property (nonatomic, copy) NSString *singerName;
+
+/**
+ * @note 音乐时长, 单位毫秒
+ */
+@property (nonatomic, assign) UInt32 duration;
+
+/**歌词信息 LRC格式
+ * @note 长度不能超过32K
+ */
+@property (nonatomic, copy) NSString *songLyric;
+
+/**高清封面图
+ * @note 大小不能超过1M
+ */
+@property (nonatomic, strong) NSData *hdAlbumThumbData;
+
+/**音乐专辑名称
+ * @note 长度不能超过1k
+ */
+@property (nonatomic, copy, nullable) NSString *albumName;
+
+/**音乐流派
+ * @note 长度不能超过1k
+ */
+@property (nonatomic, copy, nullable) NSString *musicGenre;
+
+/**发行时间
+ * @note Unix时间戳，单位为秒
+ */
+@property (nonatomic, assign) UInt64 issueDate;
+
+/**音乐标识符
+ * @note 长度不能超过1K，从微信跳回应用时会带上
+ */
+@property (nonatomic, copy, nullable) NSString *identification;
+
+/**运营H5地址
+ * @note 选填，建议填写，用户进入歌曲详情页将展示内嵌的运营H5，可展示该歌曲的相关评论、歌曲推荐等内容，不可诱导下载、分享等。
+ */
+@property (nonatomic, copy, nullable) NSString *musicOperationUrl;
+
+@end
+
+
+
+#pragma mark - WXVideoObject
+/*! @brief 多媒体消息中包含的视频数据对象
+ *
+ * 微信终端和第三方程序之间传递消息中包含的视频数据对象。
+ * @note videoUrl和videoLowBandUrl不能同时为空。
+ * @see WXMediaMessage
+ */
+@interface WXVideoObject : NSObject
+/*! @brief 返回一个WXVideoObject对象
+ *
+ * @note 返回的WXVideoObject对象是自动释放的
+ */
++ (WXVideoObject *)object;
+
+/** 视频网页的url地址
+ * @note 长度不能超过10K
+ */
+@property (nonatomic, copy) NSString *videoUrl;
+/** 视频lowband网页的url地址
+ * @note 长度不能超过10K
+ */
+@property (nonatomic, copy) NSString *videoLowBandUrl;
+
+@end
+
+
+
+#pragma mark - WXWebpageObject
+/*! @brief 多媒体消息中包含的网页数据对象
+ *
+ * 微信终端和第三方程序之间传递消息中包含的网页数据对象。
+ * @see WXMediaMessage
+ */
+@interface WXWebpageObject : NSObject
+/*! @brief 返回一个WXWebpageObject对象
+ *
+ * @note 返回的WXWebpageObject对象是自动释放的
+ */
++ (WXWebpageObject *)object;
+
+/** 网页的url地址
+ * @note 不能为空且长度不能超过10K
+ */
+@property (nonatomic, copy) NSString *webpageUrl;
+
+@end
+
+
+
+#pragma mark - WXAppExtendObject
+/*! @brief 多媒体消息中包含的App扩展数据对象
+ *
+ * 第三方程序向微信终端发送包含WXAppExtendObject的多媒体消息，
+ * 微信需要处理该消息时，会调用该第三方程序来处理多媒体消息内容。
+ * @note url，extInfo和fileData不能同时为空
+ * @see WXMediaMessage
+ */
+@interface WXAppExtendObject : NSObject
+/*! @brief 返回一个WXAppExtendObject对象
+ *
+ * @note 返回的WXAppExtendObject对象是自动释放的
+ */
++ (WXAppExtendObject *)object;
+
+/** 若第三方程序不存在，微信终端会打开该url所指的App下载地址
+ * @note 长度不能超过10K
+ */
+@property (nonatomic, copy) NSString *url;
+/** 第三方程序自定义简单数据，微信终端会回传给第三方程序处理
+ * @note 长度不能超过2K
+ */
+@property (nonatomic, copy, nullable) NSString *extInfo;
+/** App文件数据，该数据发送给微信好友，微信好友需要点击后下载数据，微信终端会回传给第三方程序处理
+ * @note 大小不能超过10M
+ */
+@property (nonatomic, strong, nullable) NSData *fileData;
+
+@end
+
+
+
+#pragma mark - WXEmoticonObject
+/*! @brief 多媒体消息中包含的表情数据对象
+ *
+ * 微信终端和第三方程序之间传递消息中包含的表情数据对象。
+ * @see WXMediaMessage
+ */
+@interface WXEmoticonObject : NSObject
+
+/*! @brief 返回一个WXEmoticonObject对象
+ *
+ * @note 返回的WXEmoticonObject对象是自动释放的
+ */
++ (WXEmoticonObject *)object;
+
+/** 表情真实数据内容
+ * @note 大小不能超过10M
+ */
+@property (nonatomic, strong) NSData *emoticonData;
+
+@end
+
+
+
+#pragma mark - WXFileObject
+/*! @brief 多媒体消息中包含的文件数据对象
+ *
+ * @see WXMediaMessage
+ */
+@interface WXFileObject : NSObject
+
+/*! @brief 返回一个WXFileObject对象
+ *
+ * @note 返回的WXFileObject对象是自动释放的
+ */
++ (WXFileObject *)object;
+
+/** 文件后缀名
+ * @note 长度不超过64字节
+ */
+@property (nonatomic, copy) NSString *fileExtension;
+
+/** 文件真实数据内容
+ * @note 大小不能超过10M
+ */
+@property (nonatomic, strong) NSData *fileData;
+
+@end
+
+
+#pragma mark - WXLocationObject
+/*! @brief 多媒体消息中包含的地理位置数据对象
+ *
+ * 微信终端和第三方程序之间传递消息中包含的地理位置数据对象。
+ * @see WXMediaMessage
+ */
+@interface WXLocationObject : NSObject
+
+/*! @brief 返回一个WXLocationObject对象
+ *
+ * @note 返回的WXLocationObject对象是自动释放的
+ */
++ (WXLocationObject *)object;
+
+/** 地理位置信息
+ * @note 经纬度
+ */
+@property (nonatomic, assign) double lng; //经度
+@property (nonatomic, assign) double lat; //纬度
+
+@end
+
+#pragma mark - WXTextObject
+/*! @brief 多媒体消息中包含的文本数据对象
+ *
+ * 微信终端和第三方程序之间传递消息中包含的文本数据对象。
+ * @see WXMediaMessage
+ */
+@interface WXTextObject : NSObject
+
+/*! @brief 返回一个WXTextObject对象
+ *
+ * @note 返回的WXTextObject对象是自动释放的
+ */
++ (WXTextObject *)object;
+
+/** 地理位置信息
+ * @note 文本内容
+ */
+@property (nonatomic, copy) NSString *contentText;
+
+@end
+
+#pragma mark - WXMiniProgramObject
+
+@interface WXMiniProgramObject : NSObject
+
+/*! @brief WXMiniProgramObject对象
+ *
+ * @note 返回的WXMiniProgramObject对象是自动释放的
+ */
++ (WXMiniProgramObject *)object;
+
+/** 低版本网页链接
+ * @attention 长度不能超过1024字节
+ */
+@property (nonatomic, copy) NSString *webpageUrl;
+
+/** 小程序username */
+@property (nonatomic, copy) NSString *userName;
+
+/** 小程序页面的路径
+ * @attention 不填默认拉起小程序首页
+ */
+@property (nonatomic, copy, nullable) NSString *path;
+
+/** 小程序新版本的预览图
+ * @attention 大小不能超过128k
+ */
+@property (nonatomic, strong, nullable) NSData *hdImageData;
+
+/** 是否使用带 shareTicket 的转发 */
+@property (nonatomic, assign) BOOL withShareTicket;
+
+/** 分享小程序的版本
+ * @attention （正式，开发，体验）
+ */
+@property (nonatomic, assign) WXMiniProgramType miniProgramType;
+
+/** 是否禁用转发 */
+@property (nonatomic, assign) BOOL disableForward;
+
+@property (nonatomic, assign) BOOL isUpdatableMessage;
+
+@property (nonatomic, assign) BOOL isSecretMessage;
+
+
+/** 业务所需的额外信息 */
+@property (nonatomic, strong, nullable) NSDictionary *extraInfoDic;
+
+@end
+
+#pragma mark - WXGameLiveObject
+
+/*! @brief WXGameLiveObject对象
+ *
+ * @note 游戏直播消息类型
+ */
+
+@interface WXGameLiveObject : NSObject
+
++ (WXGameLiveObject *)object;
+
+/** 业务所需的额外信息 */
+@property (nonatomic, strong, nullable) NSDictionary *extraInfoDic;
+
+@end
+
+#pragma mark - WXLaunchMiniProgramReq
+
+/*! @brief WXLaunchMiniProgramReq对象, 可实现通过sdk拉起微信小程序
+ *
+ * @note 返回的WXLaunchMiniProgramReq对象是自动释放的
+ */
+@interface WXLaunchMiniProgramReq : BaseReq
+
++ (WXLaunchMiniProgramReq *)object;
+
+/** 小程序username */
+@property (nonatomic, copy) NSString *userName;
+
+/** 小程序页面的路径
+ * @attention 不填默认拉起小程序首页
+ */
+@property (nonatomic, copy, nullable) NSString *path;
+
+/** 分享小程序的版本
+ * @attention （正式，开发，体验）
+ */
+@property (nonatomic, assign) WXMiniProgramType miniProgramType;
+
+/** ext信息
+ * @attention json格式
+ */
+@property (nonatomic, copy, nullable) NSString *extMsg;
+
+/** extDic
+ * @attention 字典，可存放图片等比较大的数据
+ */
+@property (nonatomic, copy, nullable) NSDictionary *extDic;
+
+@end
+
+#pragma mark - WXLaunchMiniProgramResp
+/*! @brief 微信终端向第三方程序返回的WXLaunchMiniProgramReq处理结果。
+ *
+ * 第三方程序向微信终端发送WXLaunchMiniProgramReq后，微信发送回来的处理结果，该结果用WXLaunchMiniProgramResp表示。
+ */
+@interface WXLaunchMiniProgramResp : BaseResp
+
+@property (nonatomic, copy, nullable) NSString *extMsg;
+
+@end
+
+
+#pragma mark - WXOpenBusinessViewReq
+/*! @brief WXOpenBusinessViewReq对象, 可实现第三方通知微信启动，打开业务页面
+ *
+ * @note 返回的WXOpenBusinessViewReq对象是自动释放的
+ */
+
+@interface WXOpenBusinessViewReq : BaseReq
+
++ (WXOpenBusinessViewReq *)object;
+
+/** 业务类型
+ */
+@property (nonatomic, copy) NSString *businessType;
+
+/** 业务参数
+ */
+@property (nonatomic, copy, nullable) NSString *query;
+
+/** ext信息
+ * @note 选填，json格式
+ */
+@property (nonatomic, copy, nullable) NSString *extInfo;
+
+/** extData数据
+ * @note
+ */
+@property (nonatomic, strong, nullable) NSData *extData;
+@end
+
+
+@interface WXOpenBusinessViewResp : BaseResp
+
+/** 业务类型
+ */
+@property (nonatomic, copy) NSString *businessType;
+
+/** 业务返回数据
+ */
+@property (nonatomic, copy, nullable) NSString *extMsg;
+
+@end
+
+#pragma mark - WXOpenCustomerServiceReq
+@interface WXOpenCustomerServiceReq : BaseReq
+
++ (WXOpenCustomerServiceReq *)object;
+
+/**企微客服发起流程 url
+ */
+@property (nonatomic, copy, nullable) NSString *url;
+
+/**企业 id
+ */
+@property (nonatomic, copy, nullable) NSString *corpid;
+
+@end
+
+@interface WXOpenCustomerServiceResp : BaseResp
+
+/** 业务返回数据
+ */
+@property (nonatomic, copy, nullable) NSString *extMsg;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/libs/WechatAuthSDK.h
+++ b/src/ios/libs/WechatAuthSDK.h
@@ -1,0 +1,68 @@
+//
+//  WechatAuthSDK.h
+//  WechatAuthSDK
+//
+//  Created by 李凯 on 13-11-29.
+//  Copyright (c) 2013年 Tencent. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+enum  AuthErrCode {
+    WechatAuth_Err_Ok = 0,  //Auth成功
+    WechatAuth_Err_NormalErr = -1,  //普通错误
+    WechatAuth_Err_NetworkErr = -2, //网络错误
+    WechatAuth_Err_GetQrcodeFailed = -3,    //获取二维码失败
+    WechatAuth_Err_Cancel = -4,     //用户取消授权
+    WechatAuth_Err_Timeout = -5,    //超时
+};
+
+@protocol WechatAuthAPIDelegate<NSObject>
+@optional
+
+- (void)onAuthGotQrcode:(UIImage *)image;  //得到二维码
+- (void)onQrcodeScanned;    //二维码被扫描
+- (void)onAuthFinish:(int)errCode AuthCode:(nullable NSString *)authCode;    //成功登录
+
+@end
+
+@interface WechatAuthSDK : NSObject{
+    NSString *_sdkVersion;
+    __weak id<WechatAuthAPIDelegate> _delegate;
+}
+
+@property(nonatomic, weak, nullable) id<WechatAuthAPIDelegate> delegate;
+@property(nonatomic, readonly) NSString *sdkVersion;   //authSDK版本号
+
+/*! @brief 发送登录请求，等待WechatAuthAPIDelegate回调
+ *
+ * @param appId 微信开发者ID
+ * @param nonceStr 一个随机的尽量不重复的字符串，用来使得每次的signature不同
+ * @param timeStamp 时间戳
+ * @param scope 应用授权作用域，拥有多个作用域用逗号（,）分隔
+ * @param signature 签名
+ * @param schemeData 会在扫码后拼在scheme后
+ * @return 成功返回YES，失败返回NO
+    注:该实现只保证同时只有一个Auth在运行，Auth未完成或未Stop再次调用Auth接口时会返回NO。
+ */
+
+- (BOOL)Auth:(NSString *)appId
+    nonceStr:(NSString *)nonceStr
+   timeStamp:(NSString *)timeStamp
+       scope:(NSString *)scope
+   signature:(NSString *)signature
+  schemeData:(nullable NSString *)schemeData;
+
+
+/*! @brief 暂停登录请求
+ *
+ * @return 成功返回YES，失败返回NO。
+ */
+- (BOOL)StopAuth;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
更新SDK到1.9.2　最新版本
主要是配置IOS universalLink  　调起相关app
以下说明来自微信官网说明摘录：https://developers.weixin.qq.com/doc/oplatform/Mobile_App/Access_Guide/iOS.html
.................
SDK1.8.7版本，WXApi新增了自检函数checkUniversalLinkReady:，帮助开发者排查SDK接入过程中遇到的问题。

注意事项：

调用自检函数之前必须要先调用registerApp:universalLink接口, 并确认调用成功
自检过程中会有Log产生，可以先调用startLogByLevel函数，根据Log排查问题
会多次回调block
仅用于新接入SDK时调试使用，请勿在正式环境的调用
示例代码:

//在register之前打开log, 后续可以根据log排查问题
[WXApi startLogByLevel:WXLogLevelDetail logBlock:^(NSString *log) {
    NSLog(@"WeChatSDK: %@", log);
}];

//务必在调用自检函数前注册
[WXApi registerApp:APP_ID universalLink:UNIVERSAL_LINK];

//调用自检函数
[WXApi checkUniversalLinkReady:^(WXULCheckStep step, WXCheckULStepResult* result) {
    NSLog(@"%@, %u, %@, %@", @(step), result.success, result.errorInfo, result.suggestion);
}];
WXULCheckStep值说明:

step = WXULCheckStepParams: 参数检查
step = WXULCheckStepSystemVersion: 当前系统版本检查
step = WXULCheckStepWechatVersion: 微信客户端版本检查
step = WXULCheckStepSDKInnerOperation: 微信SDK内部操作检查
step = WXULCheckStepLaunchWechat: App拉起微信检查
step = WXULCheckStepBackToCurrentApp: 由微信返回当前App检查
step = WXULCheckStepFinal: 最终检查
会依次回调这7个step，当回调了WXULCheckStepFinal，说明检测通过，SDK接入成功。 任一step回调的result.success为NO, 流程终止，后续不再回调，可以根据result.errorInfo的查看当前步骤错误的原因，根据result.suggestion修复问题.